### PR TITLE
base < 4.5 compatibility

### DIFF
--- a/Data/Csv/Conversion/Internal.hs
+++ b/Data/Csv/Conversion/Internal.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Data.Csv.Conversion.Internal
     ( decimal
     , realFloat
@@ -10,7 +11,11 @@ import Data.Array.IArray
 import qualified Data.ByteString as B
 import Data.Char (ord)
 import Data.Int
+#if MIN_VERSION_base(4,5,0)
 import Data.Monoid
+#else
+import Data.Monoid.CompatBase44
+#endif
 import Data.Word
 
 ------------------------------------------------------------------------

--- a/Data/Csv/Encoding.hs
+++ b/Data/Csv/Encoding.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE BangPatterns, OverloadedStrings #-}
+{-# LANGUAGE BangPatterns, CPP, OverloadedStrings #-}
 
 -- Module:      Data.Csv.Encoding
 -- Copyright:   (c) 2011 MailRank, Inc.
@@ -38,6 +38,9 @@ import qualified Data.ByteString.Lazy as L
 import qualified Data.ByteString.Lazy.Char8 as BL8
 import qualified Data.HashMap.Strict as HM
 import Data.Monoid
+#if !MIN_VERSION_base(4,5,0)
+import Data.Monoid.CompatBase44
+#endif
 import Data.Traversable
 import Data.Vector (Vector)
 import qualified Data.Vector as V
@@ -47,6 +50,15 @@ import Prelude hiding (unlines)
 import Data.Csv.Conversion
 import Data.Csv.Parser
 import Data.Csv.Types
+
+-- #if !MIN_VERSION_base(4,5,0)
+-- infixr 6 <>
+
+-- -- | An infix synonym for 'mappend'.
+-- (<>) :: Monoid m => m -> m -> m
+-- (<>) = mappend
+-- {-# INLINE (<>) #-}
+-- #end if
 
 -- TODO: 'encode' isn't as efficient as it could be.
 

--- a/Data/Monoid/CompatBase44.hs
+++ b/Data/Monoid/CompatBase44.hs
@@ -1,0 +1,12 @@
+-- | This is a compatibility hack for base < 4.5
+
+module Data.Monoid.CompatBase44 where
+
+import Data.Monoid
+
+infixr 6 <>
+-- | An infix synonym for 'mappend'.
+(<>) :: Monoid m => m -> m -> m
+(<>) = mappend
+{-# INLINE (<>) #-}
+

--- a/cassava.cabal
+++ b/cassava.cabal
@@ -27,6 +27,7 @@ Library
                        Data.Csv.Conversion.Internal
                        Data.Csv.Encoding
                        Data.Csv.Types
+                       Data.Monoid.CompatBase44
 
   Build-depends:       array,
                        attoparsec >= 0.10.2,


### PR DESCRIPTION
Here's the base < 4.5 compatibility patch. I ran the tests and benchmarks on base==4.3.1.0, but I didn't have a chance to test it with a more recent version. Please double-check.
