### PR TITLE
Add NonEmpty newtype

### DIFF
--- a/Data/Csv.hs
+++ b/Data/Csv.hs
@@ -51,6 +51,7 @@ module Data.Csv
     , ToRecord(..)
     , record
     , Only(..)
+    , NonEmpty(..)
 
     -- ** Name-based record conversion
     -- $namebased


### PR DESCRIPTION
Hi Johan,

I used this at work and it seems useful in general.

I'm not married to the name at all. It could also be called:

``` haskell
newtype NonNull a = NonNull {nonNull :: a}
```

Or something similar...

Cheers,

Bas
