### PR TITLE
Add FromField instance for ()

### DIFF
--- a/Data/Csv.hs
+++ b/Data/Csv.hs
@@ -143,7 +143,15 @@ import Data.Csv.Types
 -- >     Left err -> putStrLn err
 -- >     Right v  -> forM_ v $ \ (Hex val1, Hex val2) ->
 -- >         print (val1, val2)
-
+--
+-- In order to ignore column you can use unit type '()'. It always
+-- successfully decode. Note that it lacks corresponding 'ToField'
+-- instance. It serves as placeholder to indicate that there's
+-- something in the column you don't care what.
+--
+-- > case decode False "foo,1\r\nbar,22" of
+-- >     Left  err -> putStrLn err
+-- >     Right v   -> forM_ v $ \ ((), i) -> print (i :: Int)
 
 -- $encoding
 --

--- a/Data/Csv/Conversion.hs
+++ b/Data/Csv/Conversion.hs
@@ -386,6 +386,11 @@ instance ToField a => ToField (Maybe a) where
     toField = maybe B.empty toField
     {-# INLINE toField #-}
 
+-- | Could used to ignore column during decoding.
+instance FromField () where
+    parseField _ = pure ()
+    {-# INLINE parseField #-}
+
 -- | Assumes UTF-8 encoding.
 instance FromField Char where
     parseField s


### PR DESCRIPTION
It's useful in cases when one wants to ignore column's value. Quoting from documentation:

```
-- In order to ignore column you can use unit type '()'. It always
-- successfully decode. Note that it lacks corresponding 'ToField'
-- instance. It serves as placeholder to indicate that there's
-- something in the column you don't care what.
--
-- > case decode False "foo,1\r\nbar,22" of
-- >     Left  err -> putStrLn err
-- >     Right v   -> forM_ v $ \ ((), i) -> print (i :: Int)
```
