### PR TITLE
Escaping performance improvement

### DIFF
--- a/Data/Csv/Encoding.hs
+++ b/Data/Csv/Encoding.hs
@@ -172,10 +172,9 @@ encodeRecord delim = mconcat . intersperse (fromWord8 delim)
 
 -- TODO: Optimize
 escape :: B.ByteString -> B.ByteString
-escape s =
-    if B.any (\ b -> b == dquote || b == comma || b == nl || b == cr || b == sp)
-        s
-        then toByteString $
+escape s
+    | B.any (\ b -> b == dquote || b == comma || b == nl || b == cr || b == sp)
+        s = toByteString $
             fromWord8 dquote
             <> B.foldl
                 (\ acc b -> acc <> if b == dquote
@@ -184,7 +183,7 @@ escape s =
                 mempty
                 s
             <> fromWord8 dquote
-        else s
+    | otherwise = s
   where
     dquote = 34
     comma  = 44


### PR DESCRIPTION
Hi Johan,
here is a wee patch to improve the performance of the escape function. In my benchmarks, the new version is between 10% (if the string doesn't need to be escaped) and 50% (if it does) faster than the old version. Your benchmarks show a ~15% improvement in encoding performance.
The tests still pass.
Cheers,
Florian
