### PR TITLE
Allow only carriage return as line break

### DIFF
--- a/Data/Csv/Encoding.hs
+++ b/Data/Csv/Encoding.hs
@@ -33,7 +33,7 @@ import Blaze.ByteString.Builder (Builder, fromByteString, fromWord8,
                                  toLazyByteString, toByteString)
 import Blaze.ByteString.Builder.Char8 (fromString)
 import Control.Applicative ((*>), (<|>), optional, pure)
-import Data.Attoparsec.Char8 (endOfInput, endOfLine)
+import Data.Attoparsec.Char8 (endOfInput)
 import qualified Data.Attoparsec.ByteString.Lazy as AL
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as B8
@@ -54,7 +54,7 @@ import Data.Csv.Parser hiding (csv, csvWithHeader)
 import qualified Data.Csv.Parser as Parser
 import Data.Csv.Types hiding (toNamedRecord)
 import qualified Data.Csv.Types as Types
-import Data.Csv.Util (blankLine)
+import Data.Csv.Util (blankLine, endOfLine)
 
 -- TODO: 'encode' isn't as efficient as it could be.
 

--- a/Data/Csv/Incremental.hs
+++ b/Data/Csv/Incremental.hs
@@ -29,7 +29,7 @@ module Data.Csv.Incremental
 
 import Control.Applicative ((<*), (<|>))
 import qualified Data.Attoparsec as A
-import Data.Attoparsec.Char8 (endOfInput, endOfLine)
+import Data.Attoparsec.Char8 (endOfInput)
 import qualified Data.ByteString as B
 import qualified Data.Vector as V
 
@@ -37,6 +37,7 @@ import Data.Csv.Conversion hiding (Parser, record, toNamedRecord)
 import qualified Data.Csv.Conversion as Conversion
 import Data.Csv.Parser
 import Data.Csv.Types
+import Data.Csv.Util (endOfLine)
 
 -- $feed-header
 --

--- a/Data/Csv/Parser.hs
+++ b/Data/Csv/Parser.hs
@@ -27,7 +27,7 @@ module Data.Csv.Parser
 import Blaze.ByteString.Builder (fromByteString, toByteString)
 import Blaze.ByteString.Builder.Char.Utf8 (fromChar)
 import Control.Applicative ((*>), (<$>), (<*), optional, pure)
-import Data.Attoparsec.Char8 (char, endOfInput, endOfLine)
+import Data.Attoparsec.Char8 (char, endOfInput)
 import qualified Data.Attoparsec as A
 import qualified Data.Attoparsec.Lazy as AL
 import qualified Data.Attoparsec.Zepto as Z
@@ -38,7 +38,7 @@ import qualified Data.Vector as V
 import Data.Word (Word8)
 
 import Data.Csv.Types
-import Data.Csv.Util ((<$!>), blankLine, liftM2')
+import Data.Csv.Util ((<$!>), blankLine, endOfLine, liftM2', cr, newline, doubleQuote)
 
 -- | Options that controls how data is decoded. These options can be
 -- used to e.g. decode tab-separated data instead of comma-separated
@@ -186,8 +186,3 @@ unescape = toByteString <$!> go mempty where
     if done
       then return (acc `mappend` fromByteString h)
       else rest
-
-doubleQuote, newline, cr :: Word8
-doubleQuote = 34
-newline = 10
-cr = 13

--- a/Data/Csv/Util.hs
+++ b/Data/Csv/Util.hs
@@ -1,13 +1,22 @@
-{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE BangPatterns, OverloadedStrings #-}
 
 module Data.Csv.Util
     ( (<$!>)
     , blankLine
     , liftM2'
+    , endOfLine
+    , doubleQuote
+    , newline
+    , cr
     ) where
 
+import Control.Applicative ((<|>), (*>))
+import Data.Word (Word8)
+import Data.Attoparsec.ByteString.Char8 (string)
+import qualified Data.Attoparsec as A
 import qualified Data.ByteString as B
 import qualified Data.Vector as V
+import Data.Attoparsec.Types (Parser)
 
 -- | A strict version of 'Data.Functor.<$>' for monads.
 (<$!>) :: Monad m => (a -> b) -> m a -> m b
@@ -30,3 +39,16 @@ liftM2' f a b = do
     y <- b
     return (f x y)
 {-# INLINE liftM2' #-}
+
+
+-- | Match either a single newline character @\'\\n\'@, or a carriage
+-- return followed by a newline character @\"\\r\\n\"@, or a single
+-- carriage return @\'\\r\'@.
+endOfLine :: Parser B.ByteString ()
+endOfLine = (A.word8 newline *> return ()) <|> (string "\r\n" *> return ()) <|> (A.word8 cr *> return ())
+{-# INLINE endOfLine #-}
+
+doubleQuote, newline, cr :: Word8
+doubleQuote = 34
+newline = 10
+cr = 13

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -192,6 +192,9 @@ nameBasedTests =
            [[("field1", "abc"), ("field2", "def")]])
         , ("twoRecords", "field\r\nabc\r\ndef\r\n", ["field"],
            [[("field", "abc")], [("field", "def")]])
+        , ("cr header", "field\rabc", ["field"], [[("field", "abc")]])
+        , ("cr trailing", "field\rabc\r", ["field"], [[("field", "abc")]])
+        , ("cr separator", "field\rabc\rdef", ["field"], [[("field", "abc")],[("field","def")]])
         ]
 
     encodeTest (name, hdr, input, expected) =


### PR DESCRIPTION
Some Mac applications (Notably MS Office) uses `\r` for line-breaks by default, this commit allows parsing of these files.

It's just a dumb replacement of all occurences of `endOfLine` to take this case into account. I'm suprised that I didn't have to change `sepByEndOfLine1'` for this to work, but my tests pass and the CSV I started out with parses correctly too.

I also moved `cr` and friends to `Util` since `endOfLine'` was needed in modules other than `Parser`.
