### PR TITLE
Trim whitespaces for numeric fields

### DIFF
--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -244,6 +244,12 @@ partialDecode p = case runParser p of
   Left _  -> return ()
   Right _ -> assertFailure "expected partial field decode"
 
+expect :: (Eq a, Show a) => Parser a -> a -> Assertion
+expect p a0 =
+  case runParser p of
+    Right a -> a @=? a0
+    Left  e -> assertFailure e
+
 conversionTests :: [TF.Test]
 conversionTests =
     [ testGroup "roundTrip"
@@ -293,6 +299,17 @@ conversionTests =
                             (parseField "1.0+" :: Parser Double))
       , testCase "Integer" (partialDecode
                             (parseField "1e6"  :: Parser Integer))
+      ]
+    , testGroup "Space trimming"
+      [ testCase "_Int"     (expect (parseField " 12"     :: Parser Int)    12)
+      , testCase "Int_"     (expect (parseField "12 "     :: Parser Int)    12)
+      , testCase "_Int_"    (expect (parseField " 12 "    :: Parser Int)    12)
+      , testCase "_Word"    (expect (parseField " 12"     :: Parser Word)   12)
+      , testCase "Word_"    (expect (parseField "12 "     :: Parser Word)   12)
+      , testCase "_Word_"   (expect (parseField " 12 "    :: Parser Word)   12)
+      , testCase "_Double"  (expect (parseField " 1.2e1"  :: Parser Double) 12)
+      , testCase "Double_"  (expect (parseField "1.2e1 "  :: Parser Double) 12)
+      , testCase "_Double_" (expect (parseField " 1.2e1 " :: Parser Double) 12)
       ]
     ]
 


### PR DESCRIPTION
This pull request implements trimming of whitespaces for numeric fields as was suggested in #53 by me. It's implemented by changes to parse{Double,Signed,Unsigned}. Tests are included.

It leads to ~5% or so slowdown. Exact numbers fluctuate between benchmark runs

```
                                                       name  new/old
1           positional/decode/presidents/without conversion 1.0887817
2              positional/decode/presidents/with conversion 1.0261922
3 positional/decode/streaming/presidents/without conversion 0.9288449
4    positional/decode/streaming/presidents/with conversion 1.0274190
5              positional/encode/presidents/with conversion 0.9919386
6                named/decode/presidents/without conversion 1.0618138
7                   named/decode/presidents/with conversion 0.9508360
8                   named/encode/presidents/with conversion 0.9962220
9                                       comparison/lazy-csv 0.9730873  
```

P.S. below R script I used to generate table. Maybe it could be useful too

```
compare <- function(baseline,test) {
    q1 <- read.csv(baseline,stringsAsFactors = FALSE)
    q2 <- read.csv(test,    stringsAsFactors = FALSE)

    slowdown <- as.numeric(q2$Mean) / as.numeric( q1$Mean )
    plot(slowdown, col='red')
    abline(h=1)
    abline(h=mean(slowdown), col='red')
    #
    print( data.frame(name=q1$Name, slowdown=slowdown))
}
```
