### PR TITLE
decode option to ignore failing rows for named records

### DIFF
--- a/Data/Csv/Encoding.hs
+++ b/Data/Csv/Encoding.hs
@@ -331,7 +331,12 @@ csvWithHeader !opts = do
         if blankLine r
             then (endOfLine *> records hdr) <|> pure []
             else case runParser (convert hdr r) of
-                Left msg  -> fail $ "conversion error: " ++ msg
+                Left msg  ->
+                    if ignoreFailingRows opts
+                       then do !vals <- (endOfLine *> records hdr) <|> pure []
+                               return vals
+
+                       else fail $ "conversion error: " ++ msg
                 Right val -> do
                     !vals <- (endOfLine *> records hdr) <|> pure []
                     return (val : vals)

--- a/Data/Csv/Parser.hs
+++ b/Data/Csv/Parser.hs
@@ -54,12 +54,14 @@ import Data.Csv.Util ((<$!>), blankLine, endOfLine, liftM2', cr, newline, double
 data DecodeOptions = DecodeOptions
     { -- | Field delimiter.
       decDelimiter  :: {-# UNPACK #-} !Word8
+    , ignoreFailingRows :: {-# UNPACK #-} !Bool
     } deriving (Eq, Show)
 
 -- | Decoding options for parsing CSV files.
 defaultDecodeOptions :: DecodeOptions
 defaultDecodeOptions = DecodeOptions
     { decDelimiter = 44  -- comma
+    , ignoreFailingRows = False
     }
 
 -- | Parse a CSV file that does not include a header.


### PR DESCRIPTION
I have added an option to ignore failing rows for named record decoding. This is very useful for parsing human-generated CSV files from spreadsheets, which often leave blank or near-blank rows below the main content.
