### PR TITLE
Bump text upper version bounds

### DIFF
--- a/cassava.cabal
+++ b/cassava.cabal
@@ -42,7 +42,7 @@ Library
     bytestring < 0.11,
     containers < 0.6,
     deepseq < 1.4,
-    text < 1.2,
+    text < 1.3,
     unordered-containers < 0.3,
     vector < 0.11
 


### PR DESCRIPTION
Allow `cassava` to use `text-1.2.0.0`.
