### PR TITLE
Parameterized record parsers

### DIFF
--- a/Data/Csv.hs
+++ b/Data/Csv.hs
@@ -48,7 +48,9 @@ module Data.Csv
     , DecodeOptions(..)
     , defaultDecodeOptions
     , decodeWith
+    , decodeWithP
     , decodeByNameWith
+    , decodeByNameWithP
     , EncodeOptions(..)
     , Quoting(..)
     , defaultEncodeOptions

--- a/cassava.cabal
+++ b/cassava.cabal
@@ -83,9 +83,9 @@ Library
     Data.Csv.Incremental
     Data.Csv.Parser
     Data.Csv.Streaming
+    Data.Csv.Conversion
 
   Other-modules:
-    Data.Csv.Conversion
     Data.Csv.Conversion.Internal
     Data.Csv.Encoding
     Data.Csv.Types


### PR DESCRIPTION
This is a rebased version of #78 with updates to the incremental parsers as well.
## Additions
- decodeWithP
- decodeByNameWithP 

These new functions take a parser function instead of using the one provided by the FromRecord / FromNamedRecord instances. 

This allows you to use parameterized record parsers, a very common task.

Closes #67 
