### PR TITLE
Allow containers 0.6, as released with GHC 8.6.

### DIFF
--- a/cassava.cabal
+++ b/cassava.cabal
@@ -96,7 +96,7 @@ Library
     attoparsec >= 0.11.3.0 && < 0.14,
     base >= 4.5 && < 5,
     bytestring >= 0.9.2 && < 0.11,
-    containers >= 0.4.2 && < 0.6,
+    containers >= 0.4.2 && < 0.7,
     deepseq >= 1.1 && < 1.5,
     hashable < 1.3,
     scientific >= 0.3.4.7 && < 0.4,


### PR DESCRIPTION
After this is merged, a release or revision would be handy, please.