### PR TITLE
Parameterized record parsers. take 3

### DIFF
--- a/Data/Csv.hs
+++ b/Data/Csv.hs
@@ -48,7 +48,9 @@ module Data.Csv
     , DecodeOptions(..)
     , defaultDecodeOptions
     , decodeWith
+    , decodeWithP
     , decodeByNameWith
+    , decodeByNameWithP
     , EncodeOptions(..)
     , Quoting(..)
     , defaultEncodeOptions

--- a/Data/Csv/Encoding.hs
+++ b/Data/Csv/Encoding.hs
@@ -59,7 +59,6 @@ import Data.Csv.Conversion (FromNamedRecord, FromRecord, ToNamedRecord,
                             ToRecord, parseNamedRecord, parseRecord, runParser,
                             toNamedRecord, toRecord)
 import Data.Csv.Parser hiding (csv, csvWithHeader)
-import qualified Data.Csv.Conversion as Conversion
 import qualified Data.Csv.Parser as Parser
 import Data.Csv.Types hiding (toNamedRecord)
 import qualified Data.Csv.Types as Types

--- a/cassava.cabal
+++ b/cassava.cabal
@@ -83,9 +83,9 @@ Library
     Data.Csv.Incremental
     Data.Csv.Parser
     Data.Csv.Streaming
+    Data.Csv.Conversion
 
   Other-modules:
-    Data.Csv.Conversion
     Data.Csv.Conversion.Internal
     Data.Csv.Encoding
     Data.Csv.Types

--- a/cassava.cabal
+++ b/cassava.cabal
@@ -83,9 +83,9 @@ Library
     Data.Csv.Incremental
     Data.Csv.Parser
     Data.Csv.Streaming
-    Data.Csv.Conversion
 
   Other-modules:
+    Data.Csv.Conversion
     Data.Csv.Conversion.Internal
     Data.Csv.Encoding
     Data.Csv.Types

--- a/examples/NamedBasedExplicitDecode.hs
+++ b/examples/NamedBasedExplicitDecode.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+import qualified Data.ByteString.Lazy as BL
+import Data.Csv
+import qualified Data.Vector as V
+
+data Person = Person
+    { name   :: String
+    , salary :: Int
+    }
+
+valueParse :: NamedRecord -> Parser Person
+valueParse r = Person <$> r .: "name" <*> r .: "salary"
+
+main :: IO ()
+main = do
+    csvData <- BL.readFile "salaries.csv"
+    case decodeByNameWithP valueParse defaultDecodeOptions csvData of
+        Left err -> putStrLn err
+        Right (_, v) -> V.forM_ v $ \ p ->
+            putStrLn $ name p ++ " earns " ++ show (salary p) ++ " dollars"

--- a/examples/cassava-examples.cabal
+++ b/examples/cassava-examples.cabal
@@ -42,6 +42,16 @@ executable NamedBasedDecode
     vector
   default-language:    Haskell2010
 
+executable NamedBasedExplicitDecode
+  main-is: NamedBasedExplicitDecode.hs
+  build-depends:
+    base,
+    bytestring,
+    cassava,
+    vector
+  default-language:    Haskell2010
+
+
 executable NamedBasedGeneric
   main-is: NamedBasedGeneric.hs
   build-depends:


### PR DESCRIPTION
This is a rebased version of #105.

It removes the change which made `Data.Csv.Conversion` public, as that's not needed with the cassava api as it stands today.

Tiny example included as well.

Thank you @jb55 for doing all the work! Let's get this over the line.

Closes #67 

