### PR TITLE
Drop compatibility with old versions of bytestring

### DIFF
--- a/cassava.cabal
+++ b/cassava.cabal
@@ -50,9 +50,6 @@ source-repository head
   type:     git
   location: https://github.com/hvr/cassava.git
 
-flag bytestring--LT-0_10_4
-  description: [bytestring](https://hackage.haskell.org/haskell/package/bytestring) < 0.10.4
-
 Library
   default-language: Haskell2010
   other-extensions:
@@ -97,7 +94,6 @@ Library
     array >= 0.4 && < 0.6,
     attoparsec >= 0.11.3.0 && < 0.14,
     base >= 4.5 && < 4.14,
-    bytestring >= 0.9.2 && < 0.11,
     containers >= 0.4.2 && < 0.7,
     deepseq >= 1.1 && < 1.5,
     hashable < 1.4,
@@ -106,14 +102,9 @@ Library
     transformers >= 0.2 && < 0.6,
     unordered-containers < 0.3,
     vector >= 0.8 && < 0.13,
-    Only >= 0.1 && < 0.1.1
-
-  if flag(bytestring--LT-0_10_4)
-    build-depends: bytestring <  0.10.4
-                 , bytestring-builder >= 0.10.8 && < 0.11
-  else
-    build-depends: bytestring >= 0.10.4
-                 , text-short == 0.1.*
+    Only >= 0.1 && < 0.1.1,
+    bytestring >= 0.10.4 && < 0.11,
+    text-short == 0.1.*
 
   -- GHC.Generics lived in `ghc-prim` for GHC 7.2 & GHC 7.4 only
   if impl(ghc < 7.6)


### PR DESCRIPTION
This fixes https://github.com/haskell-hvr/cassava/issues/179, but it's not a good fix. I'm putting this up mostly so that others can find it if they run into the same issue.