### PR TITLE
Fix handling of double quote for unescaped fields

### DIFF
--- a/src/Data/Csv/Parser.hs
+++ b/src/Data/Csv/Parser.hs
@@ -167,8 +167,7 @@ escapedField = do
         else return s
 
 unescapedField :: Word8 -> AL.Parser S.ByteString
-unescapedField !delim = A.takeWhile (\ c -> c /= doubleQuote &&
-                                            c /= newline &&
+unescapedField !delim = A.takeWhile (\ c -> c /= newline &&
                                             c /= delim &&
                                             c /= cr)
 


### PR DESCRIPTION
Attempts to fix #98

Up for review. Please see the issue for details. Deceptively simple so even I'm suspicious :) Tests pass.

In short, currently, the parser fails on unescaped fields containing `"` such as `abc "d"`. This allows such fields to be parsed.