### PR TITLE
Fixes handling of double quotes for unescaped fields with tests

### DIFF
--- a/src/Data/Csv/Parser.hs
+++ b/src/Data/Csv/Parser.hs
@@ -167,8 +167,7 @@ escapedField = do
         else return s
 
 unescapedField :: Word8 -> AL.Parser S.ByteString
-unescapedField !delim = A.takeWhile (\ c -> c /= doubleQuote &&
-                                            c /= newline &&
+unescapedField !delim = A.takeWhile (\ c -> c /= newline &&
                                             c /= delim &&
                                             c /= cr)
 

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -185,6 +185,7 @@ positionalTests =
            [["a", "b", "c"], ["d", "e", "f"]])
         , ("leadingSpace", " a,  b,   c\n",  [[" a", "  b", "   c"]])
         , ("rfc4180", rfc4180Input, rfc4180Output)
+        , ("unquotedTextContainingQuotes", "a\"b\"c,def\",g\"hi\",jkl\nabc,def,ghi,jkl", [["a\"b\"c", "def\"", "g\"hi\"", "jkl"], ["abc", "def", "ghi", "jkl"]])
         ]
     decodeWithTests =
         [ ("tab-delim", defDec { decDelimiter = 9 }, "1\t2", [["1", "2"]])


### PR DESCRIPTION
related to issue #98.  

This is to fix a possible Oracle / MS Excel CSV export weirdness where fields can be created which are 'unescaped' but still contain double quote characters.  While it violates RFC4180, there is no reason why we cannot parse these files correctly.  I would argue that it is more correct to parse the field without error than to terminate a field early, hence splitting the field and providing confusing error message.

Example of such a field unescaped `BSV "Frohsinn" Mehr-Ork-Gest e`.
Example of such a field escaped `"BSV ""Frohsinn"" Mehr-Ork-Gest e"`.

Both fields can appear in CSV files.  Because the first character is not a double quote, the string is considered unquoted but it can still be parsed.  Previous functionality was to error with a confusing error message due to fields being split in two at the double quote character.  

I have run tests and all seem to be passing.  I have also added a new test for this functionality.  

Although all tests are passing there is a possibility that existing code depending on the error could be affected though I believe this is unlikely.  It would be wise to test with some varied known working CSV files.  