### PR TITLE
Allow bytestring-0.11 + QuickCheck-2.14

### DIFF
--- a/cassava.cabal
+++ b/cassava.cabal
@@ -97,7 +97,7 @@ Library
     array >= 0.4 && < 0.6,
     attoparsec >= 0.11.3.0 && < 0.14,
     base >= 4.5 && < 4.15,
-    bytestring >= 0.9.2 && < 0.11,
+    bytestring >= 0.9.2 && < 0.12,
     containers >= 0.4.2 && < 0.7,
     deepseq >= 1.1 && < 1.5,
     hashable < 1.4,
@@ -158,7 +158,7 @@ Test-suite unit-tests
                , vector
   -- extra dependencies not already used by lib:cassava
   build-depends: HUnit < 1.7
-               , QuickCheck == 2.13.*
+               , QuickCheck >= 2.13 && < 2.15
                , quickcheck-instances >= 0.3.12 && < 0.4
                , test-framework == 0.8.*
                , test-framework-hunit == 0.3.*


### PR DESCRIPTION
Tested using 
```cabal
packages: .
tests: True

constraints:
  bytestring >= 0.11

source-repository-package
  type: git
  location: https://github.com/haskell/attoparsec

allow-newer:
  regex-base:bytestring,
  regex-posix:bytestring,
  uuid-types:bytestring,
  text-short:bytestring
```