### PR TITLE
improve error messages for `lookup`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## Version 0.5.3.0
+
+ * improve error messages for `lookup` and NamedRecord parsers.
+
 ## Version 0.5.2.0
 
  * Add `FromField`/`ToField` instances for `Identity` and `Const` (#158)

--- a/cassava.cabal
+++ b/cassava.cabal
@@ -1,6 +1,6 @@
 cabal-version:       1.12
 Name:                cassava
-Version:             0.5.2.0
+Version:             0.5.3.0
 Synopsis:            A CSV parsing and encoding library
 Description: {
 

--- a/src/Data/Csv/Conversion.hs
+++ b/src/Data/Csv/Conversion.hs
@@ -1148,8 +1148,11 @@ unsafeIndex v idx = parseField (V.unsafeIndex v idx)
 -- 'empty' if the field is missing or if the value cannot be converted
 -- to the desired type.
 lookup :: FromField a => NamedRecord -> B.ByteString -> Parser a
-lookup m name = maybe (fail err) parseField $ HM.lookup name m
+lookup m name = maybe (fail err) parseField' $ HM.lookup name m
   where err = "no field named " ++ show (B8.unpack name)
+        parseField' fld = case runParser (parseField fld) of
+          Left e -> fail $ "in named field " ++ show (B8.unpack name) ++ ": " ++ e
+          Right res -> pure res
 {-# INLINE lookup #-}
 
 -- | Alias for 'lookup'.


### PR DESCRIPTION
Error messages in  genericParseNamedRecord don't mention in which field the error occurs:

λ> data Person = Person
    { name   :: !String
    , salary :: !Int
    } deriving (Generic, Show)
λ> instance ToNamedRecord Person
λ> instance FromNamedRecord Person
λ> (runParser $ parseNamedRecord $ fromList [("name","Kristof"),("salary","foobar"),("foo", "32")]) :: Either String Person
Left "expected Int, got \"foobar\" (Failed reading: takeWhile1)"

This pull request changes the error message to:

Left "in named field \"salary\": expected Int, got \"foobar\" (Failed reading: takeWhile1)"