### PR TITLE
Allow transformers 0.6

### DIFF
--- a/cassava.cabal
+++ b/cassava.cabal
@@ -103,7 +103,7 @@ Library
     hashable < 1.4,
     scientific >= 0.3.4.7 && < 0.4,
     text < 1.3,
-    transformers >= 0.2 && < 0.6,
+    transformers >= 0.2 && < 0.7,
     unordered-containers < 0.3,
     vector >= 0.8 && < 0.13,
     Only >= 0.1 && < 0.1.1


### PR DESCRIPTION
The library builds cleanly with the latest `transformers-0.6.0.2`,
but I didn't manage to run the tests due to dependency resolution
issues.