### PR TITLE
Release 0.5.3.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
  * Turn flag `bytestring--LT-0_10_4` off by default (#183)
  * Doc: Add cassava usage example of reading/writing to file (#97)
  * Update to latest version of dependencies (#190, #193, #199)
- * Tested with GHC 7.4 - 9.2 (#184, #204)
+ * Tested with GHC 7.4 - 9.4 (#184, #204)
 
 ## Version 0.5.2.0
 


### PR DESCRIPTION
Candidate at: https://hackage.haskell.org/package/cassava-0.5.3.0/candidate