### PR TITLE
Enable encoding by name with missing fields

### DIFF
--- a/cassava.cabal
+++ b/cassava.cabal
@@ -1,6 +1,6 @@
 cabal-version:       1.12
 Name:                cassava
-Version:             0.5.3.0
+Version:             0.6.0.0
 Synopsis:            A CSV parsing and encoding library
 Description: {
 

--- a/src/Data/Csv/Builder.hs
+++ b/src/Data/Csv/Builder.hs
@@ -60,7 +60,7 @@ encodeRecordWith opts r =
 encodeNamedRecordWith :: ToNamedRecord a =>
                          EncodeOptions -> Header -> a -> Builder.Builder
 encodeNamedRecordWith opts hdr nr =
-    Encoding.encodeNamedRecord hdr (encQuoting opts) (encDelimiter opts)
+    Encoding.encodeNamedRecord hdr (encQuoting opts) (encDelimiter opts) (encMissing opts)
     (toNamedRecord nr) Mon.<> Encoding.recordSep (encUseCrLf opts)
 
 -- | Like 'encodeDefaultOrderedNamedRecord', but lets you customize

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -380,9 +380,24 @@ customDelim delim f1 f2 = delim `notElem` [cr, nl, dquote] ==>
     cr = 13
     dquote = 34
 
+customMissing :: Assertion
+customMissing = encodeByNameWith encOpts hdr nrs @?= ex
+  where
+    encOpts = defaultEncodeOptions { encMissing = id }
+    hdr = V.fromList ["abc", "def"]
+    nrs :: [NamedRecord]
+    nrs =
+      [ HM.fromList [("abc", "123")]
+      , HM.fromList [("def", "456")]
+      , HM.fromList [("abc", "234"), ("def", "567")]
+      , HM.fromList []
+      ]
+    ex = "abc,def\r\n123,def\r\nabc,456\r\n234,567\r\nabc,def\r\n"
+
 customOptionsTests :: [TF.Test]
 customOptionsTests =
     [ testProperty "customDelim" customDelim
+    , testCase "customMissing" customMissing
     ]
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
A new EncodeOptions field `encMissing` determines what to do when a named field cannot be found. This enables encoding sparse data structures.

This is a breaking change because there are no longer reasonable `Eq` or `Show` instances for `EncodeOptions`.

Resolves #176.
