### PR TITLE
Fix for exception on hanging doublequote

### DIFF
--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -226,7 +226,7 @@ positionalTests =
       testCase "escapedMalformed1" $
         "\"x,\"y" `decodeFailsWith` "endOfInput",
       testCase "escapedMalformed0" $
-        "baz,\"" `decodeFailsWith` "endOfInput"
+        "baz,\"" `decodeFailsWith` "Failed reading: trailing double quote"
       ]
 
 nameBasedTests :: [TF.Test]

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -224,7 +224,7 @@ positionalTests =
       testCase "escaped" $
         "\"x,y\",z\nbaz,\"bar\nfoo,\"" `decodesAs` [["x,y", "z"], ["baz", "bar\nfoo,"]],
       testCase "escapedMalformed1" $
-        "\"x,\"y" `decodeFailsWith` "endOfInput",
+        "\"x,\"y" `decodeFailsWith` "Failed reading: satisfy",
       testCase "escapedMalformed0" $
         "baz,\"" `decodeFailsWith` "Failed reading: trailing double quote"
       ]


### PR DESCRIPTION
Hi,

There's a problem with escaped fields parser, -- it is partial on opening double quote. Means, it throws Haskell `error` instead of properly failing. The problem is because of ByteString.init being called on possibly empty bytestring (w/o checking). This small PR suggest a fix for this, plus adds some tests for decoding of escaped input.