### PR TITLE
refactor: Reduce intermediate allocations in encoding logic.

### DIFF
--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -115,7 +115,7 @@ main = do
               ]
             ]
           , bgroup "encode"
-            [ bench "presidents/with conversion" $ whnf encode presidents
+            [ bench "presidents/with conversion" $ nf (BL.length . encode) presidents
             ]
           ]
         , bgroup "named"
@@ -124,7 +124,7 @@ main = do
             , bench "presidents/with conversion" $ whnf decodePresidentsN csvDataN
             ]
           , bgroup "encode"
-            [ bench "presidents/with conversion" $ whnf (encodeByName hdr) presidentsN
+            [ bench "presidents/with conversion" $ nf (BL.length . (encodeByName hdr)) presidentsN
             ]
           ]
         , bgroup "comparison"

--- a/benchmarks/cassava-iut.cabal
+++ b/benchmarks/cassava-iut.cabal
@@ -62,6 +62,7 @@ Library
     containers >= 0.4.2 && < 0.7,
     deepseq >= 1.1 && < 1.5,
     hashable < 1.5,
+    scientific >= 0.3.4.9 && < 0.4,
     text < 2.1,
     unordered-containers < 0.3,
     vector >= 0.8 && < 0.14,
@@ -90,7 +91,7 @@ Library
 
   ghc-options: -Wall -O2
 
-  hs-source-dirs: ../
+  hs-source-dirs: ../src
 
 ----------------------------------------------------------------------------
 


### PR DESCRIPTION
There were a few sources of memory inefficiency in the encode function:
* converting everything to an intermediate list rather than working with the vector.
* creating a builder, converting it to a bytestring, just to make it a builder again.

This PR removes those allocations and also takes inspiration on efficient bytestring building from [hsthrift](https://github.com/facebookincubator/hsthrift/blob/905533410f36befd4672bc388c9821a2fadd8d65/lib/Thrift/Protocol/Binary.hs#L90).

Benchmarks: 20% improvement in encoding.

had to fix the benchmark to actually be meaningful for encode since it was always returning immediately. Also augmented the presidents dataset by replicating the columns until we had 20k of them to make sure the improvements weren't noise.

Before: 

```
benchmarking positional/encode/presidents/with conversion
time                 15.21 ms   (14.52 ms .. 15.82 ms)
                     0.989 R²   (0.983 R² .. 0.995 R²)
mean                 13.57 ms   (13.26 ms .. 14.00 ms)
std dev              943.0 μs   (723.5 μs .. 1.047 ms)
variance introduced by outliers: 33% (moderately inflated)

benchmarking named/encode/presidents/with conversion
time                 22.10 ms   (21.98 ms .. 22.22 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 22.15 ms   (22.04 ms .. 22.29 ms)
std dev              280.2 μs   (204.9 μs .. 370.6 μs)
```

After:

```
benchmarking positional/encode/presidents/with conversion
time                 13.13 ms   (13.07 ms .. 13.23 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 13.14 ms   (13.10 ms .. 13.18 ms)
std dev              110.9 μs   (83.62 μs .. 159.7 μs)

benchmarking named/encode/presidents/with conversion
time                 19.80 ms   (19.62 ms .. 19.95 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 20.15 ms   (20.02 ms .. 20.47 ms)
std dev              416.2 μs   (173.1 μs .. 772.1 μs)
```

