### PR TITLE
refactor: Avoid branching in inner loop for `encodeRecord`.

### DIFF
--- a/src/Data/Csv/Encoding.hs
+++ b/src/Data/Csv/Encoding.hs
@@ -252,10 +252,11 @@ encodeOptionsError = error $ "Data.Csv: " ++
 -- | Encode a single record, without the trailing record separator
 -- (i.e. newline).
 encodeRecord :: Quoting -> Word8 -> Record -> Builder
-encodeRecord qtng delim rec =
-  case V.uncons (V.map (escape qtng delim) rec) of
+encodeRecord qtng delim rec' =
+  case V.uncons rec' of
     Nothing      -> mempty
-    Just (x, xs) -> x <> V.foldl' (\acc b -> acc <> d <> b) mempty xs
+    Just (x, xs) -> escape qtng delim x <>
+                    V.foldl' (\acc b -> acc <> d <> escape qtng delim b) mempty xs
   where
     d = word8 delim
 {-# INLINE encodeRecord #-}


### PR DESCRIPTION
Having branches in a tight loop is slightly slower/inconsistent cause of branch misprediction.