### PR TITLE
Declare the parameters of typed builders nominal

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## Version 0.5.5.0
+
+ * `Data.Csv.Incremental`: Fixed the `type role`s of `Builder` and `NamedBuilder`; they're now `nominal` in their parameters.
+
 ## Version 0.5.4.1
 
 _Andreas Abel, 2025-09-02_

--- a/cassava.cabal
+++ b/cassava.cabal
@@ -1,6 +1,6 @@
 cabal-version:       1.18
 Name:                cassava
-Version:             0.5.4.1
+Version:             0.5.5.0
 
 Synopsis:            A CSV parsing and encoding library
 Description: {
@@ -76,6 +76,7 @@ Library
     FlexibleContexts
     FlexibleInstances
     KindSignatures
+    RoleAnnotations
     MultiParamTypeClasses
     OverloadedStrings
     PolyKinds

--- a/src/Data/Csv/Incremental.hs
+++ b/src/Data/Csv/Incremental.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns, CPP, DeriveFunctor, ScopedTypeVariables #-}
+{-# LANGUAGE RoleAnnotations, KindSignatures #-}
 
 -- | This module allows for incremental decoding and encoding of CSV
 -- data. This is useful if you e.g. want to interleave I\/O with
@@ -81,6 +82,7 @@ module Data.Csv.Incremental
     , NamedBuilder
     ) where
 
+import Data.Kind (Type)
 import Control.Applicative ((<|>))
 import qualified Data.Attoparsec.ByteString as A
 import Data.Attoparsec.ByteString.Char8 (endOfInput)
@@ -357,7 +359,8 @@ encodeRecord r = Builder $ \ qtng delim useCrLf ->
 -- right-associative, 'foldr' style. Using '<>' to compose builders in
 -- a left-associative, `foldl'` style makes the building not be
 -- incremental.
-newtype Builder a = Builder {
+type role Builder  nominal
+newtype   Builder (a :: Type) = Builder {
       runBuilder :: Quoting -> Word8 -> Bool -> Builder.Builder
     }
 
@@ -434,7 +437,8 @@ encodeNamedRecord nr = NamedBuilder $ \ hdr qtng delim useCrLf ->
 -- right-associative, 'foldr' style. Using '<>' to compose builders in
 -- a left-associative, `foldl'` style makes the building not be
 -- incremental.
-newtype NamedBuilder a = NamedBuilder {
+type role NamedBuilder  nominal
+newtype   NamedBuilder (a :: Type) = NamedBuilder {
       runNamedBuilder :: Header -> Quoting -> Word8 -> Bool -> Builder.Builder
     }
 


### PR DESCRIPTION
> The parameters to `Builder` and `NamedBuilder` in `Data.Csv.Incremental` are phantom, so GHC infers the same for their roles. This allows them to be `coerce`d willy nilly, defeating their purpose of using the type system to avoid building malformed CSV.
> 
> Declaring the parameters `nominal` fixes this issue by ensuring that a given builder uses the same record construction instance throughout.

It's also good practice to give such phantoms explicit kind signatures to avoid troubles due to accidental kind polymorphism. It doesn't look like the module is using `PolyKinds` at this time, but it's the sort of extension that really should be on by default, so I've added the signatures anyway—consider it future proofing.